### PR TITLE
fix: updates `npm install` command plus some light proofreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,47 +3,47 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/react/blob/main/LICENSE) [![Docs](https://img.shields.io/badge/reference-docs-blue)](https://nillion.pub/client-ts) [![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/NillionNetwork/client-ts)](https://github.com/NillionNetwork/client-ts/issues) [![NPM Version](https://img.shields.io/npm/v/@nillion/client-wasm?label=client-wasm)](https://www.npmjs.com/package/@nillion/client-wasm) [![NPM Version](https://img.shields.io/npm/v/@nillion/client-core?label=client-core)](https://www.npmjs.com/package/@nillion/client-core)  [![NPM Version](https://img.shields.io/npm/v/@nillion/client-payments?label=client-payments)](https://www.npmjs.com/package/@nillion/client-payments) [![NPM Version](https://img.shields.io/npm/v/@nillion/client-vms?label=client-vms)](https://www.npmjs.com/package/@nillion/client-vms) [![NPM Version](https://img.shields.io/npm/v/@nillion/client-react-hooks?label=client-react-hooks)](https://www.npmjs.com/package/@nillion/client-react-hooks)
 
-Typescript client libraries for interacting with a Nillion cluster.
+TypeScript client libraries for interacting with a Nillion cluster.
 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
-- [Quick start](#quick-start)
-- [Packages and package hierarchy](#packages-and-package-hierarchy)
-- [Client configuration](#client-creation-and-configuration)
-- [React hooks](#react-hooks)
+- [Quick Start](#quick-start)
+- [Packages and Package Hierarchy](#packages-and-package-hierarchy)
+- [Client Creation and Configuration](#client-creation-and-configuration)
+- [React Hooks](#react-hooks)
 - [Logging](#logging)
-- [Nada types](#nada-types)
+- [Nada Types](#nada-types)
+- [Getting Help](#getting-help)
 
 ## Prerequisites
 
-- Only browser environments are supported.
-- All packages are ES modules.
-- Run a local development cluster with [nilup](https://docs.nillion.com/nilup).
+- Only browser environments are supported
+- All packages are ES modules
+- Run a local development cluster with [nilup](https://docs.nillion.com/nilup)
 - HTTP headers are needed in order for the browser to load the wasm bundle:
    - `Cross-Origin-Embedder-Policy: require-corp`
    - `Cross-Origin-Opener-Policy: same-origin`
-- The nilchain spawned with [nillion-devnet](https://docs.nillion.com/nillion-devnet) does not support CORS. The recommended workaround is proxy requests to nilchain for local development. 
+- The nilchain spawned with [nillion-devnet](https://docs.nillion.com/nillion-devnet) does not support CORS, therefore the recommended workaround is proxy requests to nilchain for local development
 
-## Quick start
+## Quick Start
 
 Complete examples are available at [examples/react](https://github.com/NillionNetwork/client-ts/tree/main/examples/react) or [examples/nextjs](https://github.com/NillionNetwork/client-ts/tree/main/examples/nextjs).
 
 
-1. Ensure you are running `nillion-devnet` in another terminal window.
+1. Ensure you are running `nillion-devnet` in another terminal window
 
-2. Add nillion dependencies to a your React / Next project.
+2. Add Nillion dependencies to a your React / nextjs project
 
-  ```shell 
-  // npm
-  npm i -D @nillion/client-core@latest @nillion/client-vms@latest @nillion/client-react-hooks@latest
+  ```shell
+  npm i -P @nillion/client-react-hooks@latest
   ```
 
-3. As mentioned, we have to add certain HTTP headers. Adjust your `webpack` / `next.config.mjs` configration. Please refer to the React webpack [here](https://github.com/NillionNetwork/client-ts/blob/main/examples/react/webpack.config.mjs) or nextjs [here](https://github.com/NillionNetwork/client-ts/blob/main/examples/nextjs/next.config.mjs).
+3. You have to add certain HTTP headers: adjust your `webpack` / `next.config.mjs` configration. Please refer to the [React webpack example](https://github.com/NillionNetwork/client-ts/blob/main/examples/react/webpack.config.mjs) or the [nextjs example](https://github.com/NillionNetwork/client-ts/blob/main/examples/nextjs/next.config.mjs)
 
-4. Create a client to interact with the local devnet :
+4. Create a client to interact with the local devnet:
 
-Note: If `network: NamedNetwork.enum.Devnet` is provided, then we don't need to specify bootnodes, cluster or chain since these values are copied from the partial config.
+Note: If `network: NamedNetwork.enum.Devnet` is provided, then we don't need to specify bootnodes, cluster or chain since these values are copied from the partial configuration provided.
 
   ```ts
   const client = NillionClient.create({
@@ -78,11 +78,11 @@ Note: If `network: NamedNetwork.enum.Devnet` is provided, then we don't need to 
     export default function Home() {
     const [id, setId] = useState("");
     const storeValue = useStoreValue();
-  
+
     if (storeValue.data && !id) {
       setId(storeValue.data);
     }
-  
+
     const handleStoreClick = () => {
       storeValue.mutate({
         values: {
@@ -91,7 +91,7 @@ Note: If `network: NamedNetwork.enum.Devnet` is provided, then we don't need to 
         ttl: 1,
       });
     };
-  
+
     return (
       <div>
         <h2>Hello 👋</h2>
@@ -106,20 +106,24 @@ Note: If `network: NamedNetwork.enum.Devnet` is provided, then we don't need to 
   }
   ```
 
-7. Next, run your app and click "Store". After a few seconds you should see `Status: succcess` and `Id: <uuid>` rendered. Congratulations, now you can interact with the client 🎉 
+7. Next, run your app and click "Store"
 
-8. (Optional). Once you want to switch to production ready apps, you can use the `Photon` testnet by switching the network to `Photon`. The configs can be found [here](https://github.com/NillionNetwork/client-ts/blob/main/packages/client-core/src/configs.ts). You are only required to provide a `user-seed`.
+After a few seconds you should see `Status: succcess` and `Id: <uuid>` rendered. Congratulations, now you can interact with the client. 🎉
+
+8. (Optional) Once you want to switch to production ready apps, you can use the `Photon` testnet by switching  `network` to `Photon`, then, you are only required to provide a `user-seed`
+
+[`Photon` configurations are available as well](https://github.com/NillionNetwork/client-ts/blob/main/packages/client-core/src/configs.ts).
 
 
-## Packages and package hierarchy
+## Packages and Package Hierarchy
 
-This guide focuses on `@nillion/client-vms` and `@nillion/client-react-hooks` (the other libraries are not intended for direct consumption).
+This guide focuses on `@nillion/client-vms` and `@nillion/client-react-hooks` -- other libraries are not intended for direct consumption by the end user.
 
-1. `@nillion/client-wasm` a wasm bundle and web worker for communicating with the cluster.
-2. `@nillion/client-core` manages wasm initialization and provides a wrapper for wasm functionality.  
-3. `@nillion/client-payments` the nilchain gRPC client.
-4. `@nillion/client-vms` combines functionality from `client-core` and `client-payments` into a single user-facing API.
-5. `@nillion/client-react-hooks` based on [ReactQuery](https://github.com/TanStack/query), this package provides convenience react hooks for building frontend apps.
+1. `@nillion/client-wasm` a wasm bundle and web worker for communicating with the cluster
+2. `@nillion/client-core` manages wasm initialization and provides a wrapper for wasm functionality
+3. `@nillion/client-payments` the nilchain gRPC client
+4. `@nillion/client-vms` combines functionality from `client-core` and `client-payments` into a single user-facing API
+5. `@nillion/client-react-hooks` based on [ReactQuery](https://github.com/TanStack/query): this package provides convenience react hooks for building frontend apps
 
 ```mermaid
 graph BT
@@ -131,17 +135,17 @@ graph BT
     react["@nillion/client-react-hooks"] --> client["@nillion/client-vms"]
 ```
 
-## Client creation and configuration
+## Client Creation and Configuration
 
 There are three phases to preparing a client for use:
 
-1. Wasm bundle loading and initialization.
-2. Client configuration.
-3. Client connection.
+1. Wasm bundle loading and initialization
+2. Client configuration
+3. Client connection
 
-When a `NillionClient` is created `connect(): Promise<boolean>` must be called before the client is used. This method will take care of steps 1 and 2 above and ensure the wasm bundle is correctly loaded and initialised.
+When a `NillionClient` is created `connect(): Promise<boolean>` must be called before the client is used. This method will take care of steps 1 and 2 above and ensure the wasm bundle is correctly loaded and initialized.
 
-To create a nillion client 
+To create a nillion client:
 
 ```ts
 const config: NillionClientConfig = { ... }
@@ -159,32 +163,32 @@ const config = {
     return {
       signer,
       // webpack devserver address proxied to nilchain
-      endpoint: "http://localhost:8080/nilchain", 
+      endpoint: "http://localhost:8080/nilchain",
       userSeed: "unique-user-seed",
     }
   }
 }
 ```
 
-Config key precedence (highest to lowest):
+Note: Beware of key precedence (highest to lowest):
 
-1. The overrides function.
-2. Keys defined in the `NillionClientConfig` object passed to `NillionClient.create({ ... })`.
-3. Keys from a NamedNetwork Config.
+1. The overrides function
+2. Keys defined in the `NillionClientConfig` object passed to `NillionClient.create({ ... })`
+3. Keys from a `NamedNetwork` configuration
 
-## React hooks
+## React Hooks
 
-[Quick start](#quick-start) provides the details to get started. This section builds on it and provides more details on the React hooks exported from  `@nillion/client-react-hooks`.
+[Quick Start](#quick-start) provides the details to get started. This section builds on it and provides more details on the React hooks exported from  `@nillion/client-react-hooks`.
 
 `NillionClientProvider` provides a `NillionClient` instance to child components through the `useNillion()` hook. It takes care of asynchronously connecting the client to the network and creating a `ReactQuery` client and provider. If an existing `ReactQuery` provider is detected it will be reused.
 
-The following hooks are [React Query](https://tanstack.com/query/latest/docs/framework/react/guides/queries) based:
+The following hooks are [React Query](https://tanstack.com/query/latest/docs/framework/react/guides/queries)-based:
 
 - `useFetchValue()`
 - `useFetchPermissions()`
 - `useFetchProgramOutput()`
 
-The following hooks are [React Mutation](https://tanstack.com/query/latest/docs/framework/react/guides/mutations) based:
+The following hooks are [React Mutation](https://tanstack.com/query/latest/docs/framework/react/guides/mutations)-based:
 
 - `useStoreValue()`
 - `useSetPermissions()`
@@ -192,7 +196,7 @@ The following hooks are [React Mutation](https://tanstack.com/query/latest/docs/
 - `useStoreProgram()`
 - `useRunProgram()`
 
-Hooks accept an `options` object and a React `query` or `mutation` `overrides` object. For example:
+Hooks accept an `options` object and a React `query` or `mutation` `overrides` an object. For example:
 
 ```ts
 const fetch = useFetchValue(
@@ -203,26 +207,26 @@ const fetch = useFetchValue(
   type: NadaValueType.enum.SecretString,
 },
 // react query overrides
-{ 
-  refetch: false  
+{
+  refetch: false
 });
 ```
 
 ## Logging
 
-Logging is on by default for all networks except _Photon_. To change this:
+Logging is on by default for all networks except `Photon`. To enable it for `Photon`:
 
 - Enable the `nillion:*` namespace: `const config: NillionClientConfig = { overrides: () => ({ logging : true }) }` or invoke the global helper: `window.__NILLION.enableLogging()`; or
 - If you want granular control, include `nillion:*` in your localStorage debug key: `localStorage.debug = "foo:*,nillion:*"`.
 
 Disable logging with `window.__NILLION.disableLogging()` or remove `nillion:*` from `localStorage.debug`. You may need to reload the window for changes to take effect.
 
-To enable wasm logging:
+Wasm logging is also an option, but not enabled by default. To enable it:
 
-- Start a websocket server, eg, `websocat -s 11100`.
-- After the client is initialized run `window__NILLION.enableWasmLogging()`.
+- Start a websocket server, eg, `websocat -s 11100`
+- After the client is initialized run `window__NILLION.enableWasmLogging()`
 
-## Nada types
+## Nada Types
 
 The `@nillion/client-react-hooks` and `@nillion/client-vms` packages provide convenience functions for storing nada types.
 
@@ -242,7 +246,7 @@ client.store({
 })
 ```
 
-The `values` object is converted into Nada types as follows:
+The `values` object is converted into a Nada type as follows:
 
 | Primitive    | Nada Type               |
 |--------------|-------------------------|
@@ -262,6 +266,6 @@ const values = {
 }
 ```
 
-## Getting help
+## Getting Help
 
-Ask for help in the [Nillion Github Discussions](https://github.com/orgs/NillionNetwork/discussions), or if you've found a bug with client-ts, [file an issue](https://github.com/NillionNetwork/client-ts/issues).
+Ask for help in the [Nillion Github Discussions](https://github.com/orgs/NillionNetwork/discussions), or if you've found a bug with `client-ts`, [file an issue](https://github.com/NillionNetwork/client-ts/issues).


### PR DESCRIPTION
This PR updates the `npm install` command in the mini tutorial by using `-P` rather than `-D`. It also adds minor proofreading corrections, such as American spelling of words, capitalisation of titles, usage of official names (eg Type**S**cript, nextjs), minor rephrasing, trailing space removal.