### PR TITLE
Add new hook for storing multiple NadaValues

### DIFF
--- a/packages/client-react-hooks/src/index.ts
+++ b/packages/client-react-hooks/src/index.ts
@@ -7,6 +7,7 @@ export * from "./use-nil-fetch-value";
 export * from "./use-nil-set-store-acl";
 export * from "./use-nil-store-program";
 export * from "./use-nil-store-value";
+export * from "./use-nil-store-values";
 export * from "./use-nil-update-value";
 export * from "./use-nillion";
 export * from "./use-nillion-auth";

--- a/packages/client-react-hooks/src/use-nil-store-values.ts
+++ b/packages/client-react-hooks/src/use-nil-store-values.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Days, NadaValues, StoreAcl, StoreId } from "@nillion/client-core";
+
+import { createStoreCacheKey } from "./cache-key";
+import { nilHookBaseResult, UseNilHook } from "./nil-hook-base";
+import { useNillion } from "./use-nillion";
+
+interface ExecuteArgs {
+  values: NadaValues;
+  ttl: Days;
+  acl?: StoreAcl;
+}
+
+type ExecuteResult = StoreId;
+
+type UseNilStoreValues = UseNilHook<ExecuteArgs, ExecuteResult>;
+
+export const useNilStoreValues = (): UseNilStoreValues => {
+  const { client: nilClient } = useNillion();
+  const queryClient = useQueryClient();
+
+  const mutationFn = async (args: ExecuteArgs): Promise<ExecuteResult> => {
+    const { values, ttl, acl } = args;
+    const response = await nilClient.storeValues({
+      values,
+      ttl,
+      acl,
+    });
+    if (response.err) throw response.err as Error;
+
+    const id = response.ok;
+    const key = createStoreCacheKey(id);
+    queryClient.setQueryData(key, id);
+    return id;
+  };
+
+  const mutate = useMutation({
+    mutationFn,
+  });
+
+  return {
+    execute: (args: ExecuteArgs) => {
+      mutate.mutate(args);
+    },
+    executeAsync: async (args: ExecuteArgs) => mutate.mutateAsync(args),
+    ...nilHookBaseResult(mutate),
+  };
+};


### PR DESCRIPTION
This PR introduces new Hook called `useNilStoreValues` which helps in storing multiple NadaValues using the `nilClient.storeValues()` function.

It takes in the following args:

```ts
interface ExecuteArgs {
  values: NadaValues;
  ttl: Days;
  acl?: StoreAcl;
}
```

Usage:

```tsx
import React from "react";

import { Days, NadaValue, NadaValues, NamedValue } from "@nillion/client-core";
import { useNilStoreValues } from "@nillion/client-react-hooks";

const Page = () => {
  const storeValues = useNilStoreValues();

  const onStoreValues = async () => {
    const secrets = NadaValues.create();
    secrets.insert(
      NamedValue.parse("value1"),
      NadaValue.createSecretInteger(1),
    );
    secrets.insert(
      NamedValue.parse("value2"),
      NadaValue.createSecretInteger(2),
    );

    const storeId = await storeValues.executeAsync({
      values: secrets,
      ttl: Days.parse(1),
    });

    console.log(storeId);
  };

  return (
    <div>
      <button onClick={onStoreValues}>Store Values</button>
    </div>
  );
};

export default Page;

```