### PR TITLE
Check for accounts during connect logic

### DIFF
--- a/packages/client-payments/src/client.ts
+++ b/packages/client-payments/src/client.ts
@@ -85,6 +85,10 @@ export class PaymentsClient {
     }
 
     const accounts = await this._signer.getAccounts();
+    if (!accounts[0]) {
+      throw new Error("No accounts found for provided signer.");
+    }
+
     this._address = NilChainAddress.parse(accounts[0].address);
 
     const options: SigningStargateClientOptions = {


### PR DESCRIPTION
This PR introduces a check for accounts[0] during connect logic for PaymentClient, which leads to typescript errors while building in strict mode.

This is because accounts is a array of `AccountData` and array indexing can lead to undefined typed value.