### PR TITLE
feat: add from hex for UserId

### DIFF
--- a/client-vms/src/types/user-id.test.ts
+++ b/client-vms/src/types/user-id.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { UserId } from "#/types/user-id";
+
+describe("UserId", () => {
+  it("can create a user id from a hex string", () => {
+    const hex = "0123456789abcdef08090a0b0c0d0e0f10111213";
+    const userId = UserId.fromHex(hex);
+    expect(userId.toHex()).toEqual(hex);
+  });
+});

--- a/client-vms/src/types/user-id.ts
+++ b/client-vms/src/types/user-id.ts
@@ -15,10 +15,17 @@ export class UserId {
     }
   }
 
+  static fromHex(id: string): UserId {
+    if (id.length !== 40) {
+      throw new Error(
+        `Expected hex string length to be 40 but it was ${id.length}`,
+      );
+    }
+    return new UserId(new Uint8Array(Buffer.from(id, "hex")));
+  }
+
   toHex(): string {
-    return Array.from(this.inner)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
+    return Buffer.from(this.inner).toString("hex");
   }
 
   toProto(): UserIdProto {


### PR DESCRIPTION
Add from hex for UserId so users can easily work with user ids as string.
Hex is the format that we use for UserIds in the Python client and other ids based in keys like NodeIds.