### PR TITLE
chore: bump versions client-wasm and client-vms 

### DIFF
--- a/client-vms/package.json
+++ b/client-vms/package.json
@@ -2,7 +2,7 @@
   "name": "@nillion/client-vms",
   "license": "MIT",
   "author": "devsupport@nillion.com",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0-rc.3",
   "repository": "https://github.com/NillionNetwork/client-ts",
   "type": "module",
   "exports": {

--- a/client-wasm/package.json
+++ b/client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nillion/client-wasm",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
This bumps the version of the client-wasm and client-vms