### PR TITLE
chore: reduce ci workflow times

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,38 +8,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate nillion repo app token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.NILLION_GITHUB_ACTIONS_PUBLIC_APP_ID }}
-          owner: NillionNetwork
-          private-key: ${{ secrets.NILLION_GITHUB_ACTIONS_PUBLIC_APP_PRIVATE_KEY }}
-          repositories: nillion
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          submodules: 'recursive'
-      - name: Install rustup
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-07-01
       - uses: actions/setup-node@v4
         with:
           node-version: "23"
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm build:proto
-      - run: pnpm --filter "@nillion/client-wasm" rust:check:format
-      - run: pnpm --filter "@nillion/client-wasm" rust:clippy
-      - run: pnpm --filter "@nillion/client-vms" build
-      - run: pnpm --filter "@nillion/client-react-hooks" build
       - run: pnpm exec biome format
       - run: pnpm exec biome lint
-      - run: pnpm exec tsc -p client-vms/tsconfig.json
-      - run: pnpm exec tsc -p client-react-hooks/tsconfig.json
 
-  test-client-wasm:
+  client-wasm:
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -59,45 +37,84 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2024-07-01
+          target: wasm32-unknown-unknown
       - uses: jdx/mise-action@v2
       - uses: pnpm/action-setup@v4
       - run: pnpm install
+      - run: pnpm --filter "@nillion/client-wasm" rust:check:format
+      - run: pnpm --filter "@nillion/client-wasm" rust:build
+      - run: pnpm --filter "@nillion/client-wasm" rust:clippy
+      - run: pnpm --filter "@nillion/client-wasm" build
       - run: pnpm --filter "@nillion/client-wasm" test
 
-  test-client-vms:
+  client-vms:
     needs: check
     runs-on: ubuntu-latest
     steps:
+      - name: Generate nillion repo app token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NILLION_GITHUB_ACTIONS_PUBLIC_APP_ID }}
+          owner: NillionNetwork
+          private-key: ${{ secrets.NILLION_GITHUB_ACTIONS_PUBLIC_APP_PRIVATE_KEY }}
+          repositories: nillion
       - uses: actions/checkout@v4
-        # Aws credentials are required so that nilup can access rc builds
-      - name: Get SDK Version
-        id: get-sdk-version
-        run: |
-          VERSION=$(cat .nil-sdk.toml | sed -e "s|.*\"\(.*\)\".*|\1|g")
-          echo "version=$VERSION" > $GITHUB_OUTPUT
-      - name: Install nillion SDK
-        uses: NillionNetwork/nillion-setup-action@main
         with:
-          version: ${{ steps.get-sdk-version.outputs.version }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: |
-          cd client-vms/tests-nada-programs
-          ./build.sh
+          token: ${{ steps.generate-token.outputs.token }}
+          submodules: 'recursive'
       - uses: actions/setup-node@v4
         with:
           node-version: "23.0"
       - uses: pnpm/action-setup@v4
       - run: pnpm install
+      - run: pnpm build:proto
+
+      - run: pnpm --filter "@nillion/client-vms" build
+      - run: pnpm exec tsc -p client-vms/tsconfig.json
+
+      - name: Get SDK Version
+        id: get-sdk-version
+        run: |
+          VERSION=$(cat .nil-sdk.toml | sed -e "s|.*\"\(.*\)\".*|\1|g")
+          echo "version=$VERSION" > $GITHUB_OUTPUT
+
+      - name: Install nillion SDK
+        uses: NillionNetwork/nillion-setup-action@main
+        with:
+          version: ${{ steps.get-sdk-version.outputs.version }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: |
+          cd client-vms/tests-nada-programs
+          ./build.sh
+
       - run: |
           nillion-devnet --seed test &
           sleep 10
           cd client-vms
           pnpm vitest --coverage
           killall -9 nillion-devnet
+
       - uses: davelosert/vitest-coverage-report-action@v2
         if: always()
         with:
           working-directory: ./client-vms
           comment-on: "pr"
+
+  client-react-hooks:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "23.0"
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
+      - run: pnpm --filter "@nillion/client-vms" build
+      - run: pnpm --filter "@nillion/client-react-hooks" build
+      - run: pnpm exec tsc -p client-react-hooks/tsconfig.json

--- a/client-wasm/package.json
+++ b/client-wasm/package.json
@@ -9,10 +9,12 @@
     }
   },
   "scripts": {
+    "rust:clean": "cargo clean",
+    "rust:build": "cargo build --target wasm32-unknown-unknown --release",
     "rust:check:format": "cargo fmt --check",
     "rust:format": "cargo fmt",
-    "rust:clippy": "cargo clippy",
-    "test": "wasm-pack test --node",
+    "rust:clippy": "cargo clippy --target wasm32-unknown-unknown --release",
+    "test": "wasm-pack test --node --release",
     "typecheck": "echo 'no op'; exit 0",
     "build:watch": "echo 'no op'; exit 0",
     "build": "wasm-pack build --out-dir dist --out-name index"


### PR DESCRIPTION
The latest changes increased the CI times up to more than 11 minutes because we are building the `wasm-client`. These changes reduce the time by 4 minutes.

Changes:
- Split the clients' builds into different steps. This allows executing the largest tasks (wasm building and client-vms tests) in parallel.
- Compile only once the `client-wasm`. For this, we build the `client-wasm` with `--release` and -`-target wasm32-unknown-unknown`, and later we apply the checks with these tags as well.