### PR TITLE
chore: check if the new version is higher when uploading artifacts

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -98,6 +98,7 @@ jobs:
           gh release create '${{ matrix.pkg.package-name }}-v${{ steps.check-version.outputs.local_version }}' --generate-notes $PRERELEASE --title "${{ matrix.pkg.package-name }}-v${{ steps.check-version.outputs.local_version }}"
 
       - name: Upload artifact to GH Release
+        if: steps.check-version.outputs.local_version_is_higher == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-


### PR DESCRIPTION
This checks if the new version is higher when uploading artifacts to GH. In this way, we avoid failure because the artifacts don't exist.