### PR TITLE
fix: add-funds example adds an amount higher than the minimum.

### DIFF
--- a/examples-nextjs/app/components/add-funds.tsx
+++ b/examples-nextjs/app/components/add-funds.tsx
@@ -13,7 +13,7 @@ export const AddFunds: FC = () => {
     result = mutation.error.message;
   }
 
-  const args = { amount: BigInt(10) };
+  const args = { amount: BigInt(100000) };
 
   return (
     <div>


### PR DESCRIPTION
This updates the add-funds example to add an amount of unils highest than the configured minimum.