### PR TITLE
fix: client fails when node environment

### DIFF
--- a/client-vms/package.json
+++ b/client-vms/package.json
@@ -24,6 +24,7 @@
     "@bufbuild/protobuf": "^2.2.2",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-web": "^2.0.0",
+    "@connectrpc/connect-node": "^2.0.0",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",
     "@nillion/client-wasm": "workspace:^",
@@ -48,6 +49,9 @@
     "vite-plugin-wasm": "^3.3.0",
     "vite-tsconfig-paths": "^5.1.2",
     "vitest": "^2.1.4"
+  },
+  "browser": {
+    "@connectrpc/connect-node": false
   },
   "files": ["dist"]
 }

--- a/client-vms/src/vm/client.ts
+++ b/client-vms/src/vm/client.ts
@@ -14,6 +14,7 @@ import {
   StoreValuesBuilder,
   UpdatePermissionsBuilder,
 } from "./operation";
+import type { Interceptor, Transport } from "@connectrpc/connect";
 
 /**
  * Configuration for communicating with a Nillion network node.
@@ -339,4 +340,26 @@ export class VmClient {
   retrieveComputeResult(): RetrieveComputeResultBuilder {
     return RetrieveComputeResultBuilder.init(this);
   }
+}
+
+export async function createGrpcTransport(
+  bootnodeUrl: string,
+  interceptors: Interceptor[],
+): Promise<Transport> {
+  if (typeof process !== "undefined" && process.versions?.node) {
+    return import("@connectrpc/connect-node").then((module) => {
+      return module.createGrpcWebTransport({
+        baseUrl: bootnodeUrl,
+        httpVersion: "1.1",
+        interceptors: interceptors,
+      });
+    });
+  }
+  return import("@connectrpc/connect-web").then((module) => {
+    return module.createGrpcWebTransport({
+      baseUrl: bootnodeUrl,
+      useBinaryFormat: true,
+      interceptors: interceptors,
+    });
+  });
 }

--- a/examples-nextjs/app/components/add-funds.tsx
+++ b/examples-nextjs/app/components/add-funds.tsx
@@ -13,7 +13,7 @@ export const AddFunds: FC = () => {
     result = mutation.error.message;
   }
 
-  const args = { amount: BigInt(100000) };
+  const args = { amount: BigInt(1000000) };
 
   return (
     <div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,12 @@ importers:
       '@connectrpc/connect':
         specifier: ^2.0.0
         version: 2.0.0(@bufbuild/protobuf@2.2.2)
+      '@connectrpc/connect-node':
+        specifier: ^2.0.0
+        version: 2.0.1(@bufbuild/protobuf@2.2.2)(@connectrpc/connect@2.0.0(@bufbuild/protobuf@2.2.2))
       '@connectrpc/connect-web':
         specifier: ^2.0.0
-        version: 2.0.0(@bufbuild/protobuf@2.2.2)(@connectrpc/connect@2.0.0(@bufbuild/protobuf@2.2.2))
+        version: 2.0.1(@bufbuild/protobuf@2.2.2)(@connectrpc/connect@2.0.0(@bufbuild/protobuf@2.2.2))
       '@cosmjs/proto-signing':
         specifier: ^0.32.4
         version: 0.32.4
@@ -424,11 +427,18 @@ packages:
   '@confio/ics23@0.6.8':
     resolution: {integrity: sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==}
 
-  '@connectrpc/connect-web@2.0.0':
-    resolution: {integrity: sha512-oeCxqHXLXlWJdmcvp9L3scgAuK+FjNSn+twyhUxc8yvDbTumnt5Io+LnBzSYxAdUdYqTw5yHfTSCJ4hj0QID0g==}
+  '@connectrpc/connect-node@2.0.1':
+    resolution: {integrity: sha512-jXE9vMZ71aZnIXPDBqedwQyT/nN5pYs6pI8BScvvxJEKPJNAuwxltdJ2u0RpPaqox/dEW+ipzAN7kjYQIy3NHg==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
       '@bufbuild/protobuf': ^2.2.0
-      '@connectrpc/connect': 2.0.0
+      '@connectrpc/connect': 2.0.1
+
+  '@connectrpc/connect-web@2.0.1':
+    resolution: {integrity: sha512-FmUR9TyuHu/3efr9cYZcqqAccgsswLSm3PQBXGuya5h57AjQWROW6ejL6Fg0d+A9EwsxRmJktefmFszXUMlU9Q==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+      '@connectrpc/connect': 2.0.1
 
   '@connectrpc/connect@2.0.0':
     resolution: {integrity: sha512-Usm8jgaaULANJU8vVnhWssSA6nrZ4DJEAbkNtXSoZay2YD5fDyMukCxu8NEhCvFzfHvrhxhcjttvgpyhOM7xAQ==}
@@ -2693,7 +2703,12 @@ snapshots:
       '@noble/hashes': 1.7.1
       protobufjs: 6.11.4
 
-  '@connectrpc/connect-web@2.0.0(@bufbuild/protobuf@2.2.2)(@connectrpc/connect@2.0.0(@bufbuild/protobuf@2.2.2))':
+  '@connectrpc/connect-node@2.0.1(@bufbuild/protobuf@2.2.2)(@connectrpc/connect@2.0.0(@bufbuild/protobuf@2.2.2))':
+    dependencies:
+      '@bufbuild/protobuf': 2.2.2
+      '@connectrpc/connect': 2.0.0(@bufbuild/protobuf@2.2.2)
+
+  '@connectrpc/connect-web@2.0.1(@bufbuild/protobuf@2.2.2)(@connectrpc/connect@2.0.0(@bufbuild/protobuf@2.2.2))':
     dependencies:
       '@bufbuild/protobuf': 2.2.2
       '@connectrpc/connect': 2.0.0(@bufbuild/protobuf@2.2.2)


### PR DESCRIPTION
When we execute the client from node it fails. That is because the transport module we use is only works for browsers. This allows to load dynamically the transport module depending on the execution environemnt.
- Node uses `@connectrpc/connect-node`
- Browser uses `@connectrpc/connect-web`