### PR TITLE
chore: ignore git checks when publish

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -86,7 +86,7 @@ jobs:
       - env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: steps.check-version.outputs.local_version_is_higher == 'true'
-        run: pnpm --filter "@nillion/${{ matrix.pkg.package-name }}" publish --tag ${{ steps.check-version.outputs.tag }}
+        run: pnpm --filter "@nillion/${{ matrix.pkg.package-name }}" publish --tag ${{ steps.check-version.outputs.tag }} --no-git-checks
 
       - name: Create GH Release
         id: create-release


### PR DESCRIPTION
This allows us to ignore the git checks when we publish the modules.

Probably this fails now because we don't want to update the nilvm submodule to the latest commit. It contains changes that we don't want to include in this release.