### PR TITLE
fix: bump versions and releases

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -52,8 +52,6 @@ jobs:
         with:
           toolchain: nightly-2024-07-01
           target: wasm32-unknown-unknown
-      - uses: jdx/mise-action@v2
-        if: matrix.pkg.package-name == 'client-wasm' && steps.check-version.outputs.local_version_is_higher == 'true'
 
       - uses: actions/setup-node@v4
         if: steps.check-version.outputs.local_version_is_higher == 'true'
@@ -65,11 +63,6 @@ jobs:
         if: steps.check-version.outputs.local_version_is_higher == 'true'
       - run: pnpm install
         if: steps.check-version.outputs.local_version_is_higher == 'true'
-
-      - name: Build client-wasm
-        if: matrix.pkg.package-name == 'client-wasm' && steps.check-version.outputs.local_version_is_higher == 'true'
-        run: |
-          pnpm --filter "@nillion/client-wasm" build
 
       - name: Build client-vms
         if: matrix.pkg.package-name == 'client-vms' && steps.check-version.outputs.local_version_is_higher == 'true'

--- a/client-react-hooks/package.json
+++ b/client-react-hooks/package.json
@@ -2,7 +2,7 @@
   "name": "@nillion/client-react-hooks",
   "license": "MIT",
   "author": "devsupport@nillion.com",
-  "version": "0.3.0-rc.3",
+  "version": "0.3.1",
   "homepage": "https://nillion.pub/client-ts",
   "repository": {
     "type": "git",

--- a/client-react-hooks/package.json
+++ b/client-react-hooks/package.json
@@ -2,7 +2,7 @@
   "name": "@nillion/client-react-hooks",
   "license": "MIT",
   "author": "devsupport@nillion.com",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0-rc.3",
   "homepage": "https://nillion.pub/client-ts",
   "repository": {
     "type": "git",

--- a/client-vms/package.json
+++ b/client-vms/package.json
@@ -2,7 +2,7 @@
   "name": "@nillion/client-vms",
   "license": "MIT",
   "author": "devsupport@nillion.com",
-  "version": "0.3.0-rc.4",
+  "version": "0.3.0-rc.5",
   "repository": "https://github.com/NillionNetwork/client-ts",
   "type": "module",
   "exports": {

--- a/client-vms/package.json
+++ b/client-vms/package.json
@@ -2,7 +2,7 @@
   "name": "@nillion/client-vms",
   "license": "MIT",
   "author": "devsupport@nillion.com",
-  "version": "0.3.0-rc.5",
+  "version": "0.3.1",
   "repository": "https://github.com/NillionNetwork/client-ts",
   "type": "module",
   "exports": {

--- a/client-wasm/Cargo.toml
+++ b/client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-wasm"
-version = "0.2.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/client-wasm/package.json
+++ b/client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nillion/client-wasm",
-  "version": "0.3.0-rc.6",
+  "version": "0.3.1",
   "type": "module",
   "exports": {
     ".": {

--- a/client-wasm/package.json
+++ b/client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nillion/client-wasm",
-  "version": "0.3.0-rc.3",
+  "version": "0.3.0-rc.6",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
This bumps versions and creates the releases (they have already been created and published during testing).

Client-wasm failed a couple of times because if we build it the published module is empty. In the end, it's not built, because `dist/` is already in the repository (This worked already in this way before I updated the workflow)