### PR TITLE
fix: default bootnodeurl for the testnet and parametrize client component

### DIFF
--- a/client-react-hooks/package.json
+++ b/client-react-hooks/package.json
@@ -2,7 +2,7 @@
   "name": "@nillion/client-react-hooks",
   "license": "MIT",
   "author": "devsupport@nillion.com",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://nillion.pub/client-ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This updates the default bootnodeurl for the testnet and allow parametrization to the client component to configure it from outside.