### PR TITLE
fix: eddsa signatures

### DIFF
--- a/client-react-hooks/src/create-client.ts
+++ b/client-react-hooks/src/create-client.ts
@@ -1,6 +1,6 @@
 import type { OfflineSigner } from "@cosmjs/proto-signing";
 import type { Keplr } from "@keplr-wallet/types";
-import { VmClientBuilder, type VmClient } from "@nillion/client-vms";
+import { type VmClient, VmClientBuilder } from "@nillion/client-vms";
 import { createSignerFromKey } from "@nillion/client-vms";
 import type { PaymentMode } from "@nillion/client-vms";
 

--- a/client-vms/tests/wasm.test.ts
+++ b/client-vms/tests/wasm.test.ts
@@ -25,11 +25,6 @@ const byteArray = Uint8Array.from([
   136, 145, 98, 150, 152, 122, 50, 91, 141, 227, 182, 233, 8, 245, 72, 38,
 ]);
 
-const privateKey = Uint8Array.from([
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1,
-]);
-
 const pubKey = Uint8Array.from([
   186, 236, 247, 198, 7, 225, 204, 147, 116, 47, 207, 45, 149, 49, 212, 168,
   136, 145, 98, 150, 152, 122, 50, 91, 141, 227, 182, 233, 8, 245, 72, 38, 56,
@@ -37,6 +32,11 @@ const pubKey = Uint8Array.from([
 
 const storeId = Uint8Array.from([
   186, 236, 247, 198, 7, 225, 204, 147, 116, 47, 207, 45, 149, 49, 212, 168,
+]);
+
+const eddsaPrivateKey = Uint8Array.from([
+  67, 125, 56, 30, 209, 152, 89, 230, 27, 85, 136, 128, 43, 116, 85, 113, 124,
+  43, 197, 3, 29, 148, 6, 50, 169, 92, 97, 171, 152, 26, 90, 3,
 ]);
 
 const eddsaSignatureR = Uint8Array.from([
@@ -59,98 +59,82 @@ const digestMessage = "A deep message with a deep number: 42";
 const data = [
   {
     type: "PublicInteger",
-    name: "a",
     value: -42,
     nadaValue: NadaValue.new_public_integer("-42"),
   },
   {
     type: "PublicUnsignedInteger",
-    name: "b",
     value: 42,
     nadaValue: NadaValue.new_public_unsigned_integer("42"),
   },
   {
     type: "PublicBoolean",
-    name: "c",
     value: true,
     nadaValue: NadaValue.new_public_boolean(true),
   },
   {
     type: "SecretInteger",
-    name: "d",
     value: -100,
     nadaValue: NadaValue.new_secret_integer("-100"),
   },
   {
     type: "SecretUnsignedInteger",
-    name: "e",
     value: 100,
     nadaValue: NadaValue.new_secret_unsigned_integer("100"),
   },
   {
     type: "SecretBoolean",
-    name: "f",
     value: true,
     nadaValue: NadaValue.new_secret_boolean(true),
   },
   {
     type: "SecretBlob",
-    name: "g",
     value: Uint8Array.from([1, 2, 3]),
     nadaValue: NadaValue.new_secret_blob(Uint8Array.from([1, 2, 3])),
   },
   {
     type: "EcdsaPrivateKey",
-    name: "h",
     value: ecdsaPrivateKey,
     nadaValue: NadaValue.new_ecdsa_private_key(ecdsaPrivateKey),
   },
   {
     type: "EcdsaDigestMessage",
-    name: "i",
     value: sha256(digestMessage),
     nadaValue: NadaValue.new_ecdsa_digest_message(sha256(digestMessage)),
   },
   {
     type: "EcdsaSignature",
-    name: "j",
     value: byteArray,
     nadaValue: NadaValue.new_ecdsa_signature(byteArray, byteArray),
   },
   {
     type: "EcdsaPublicKey",
-    name: "k",
     value: pubKey,
     nadaValue: NadaValue.new_ecdsa_public_key(pubKey),
   },
   {
     type: "StoreId",
-    name: "l",
     value: storeId,
     nadaValue: NadaValue.new_store_id(storeId),
   },
   {
     type: "EddsaPrivateKey",
-    name: "m",
-    value: privateKey,
-    nadaValue: NadaValue.new_eddsa_private_key(privateKey),
+    value: eddsaPrivateKey,
+    nadaValue: NadaValue.new_eddsa_private_key(eddsaPrivateKey),
   },
   {
     type: "EddsaMessage",
-    name: "n",
     value: sha256(digestMessage),
     nadaValue: NadaValue.new_eddsa_message(sha256(digestMessage)),
   },
   {
     type: "EddsaSignature",
-    name: "o",
     r: eddsaSignatureR,
     z: eddsaSignatureZ,
     nadaValue: NadaValue.new_eddsa_signature(eddsaSignatureR, eddsaSignatureZ),
   },
   {
     type: "EddsaPublicKey",
-    name: "p",
     value: eddsaPublicKey,
     nadaValue: NadaValue.new_eddsa_public_key(eddsaPublicKey),
   },
@@ -163,13 +147,13 @@ describe("Wasm compatability", () => {
     data.forEach((test, index) => {
       describe(test.type, () => {
         it("can insert into NadaValues", () => {
-          values.insert(test.name, test.nadaValue);
+          values.insert(test.type, test.nadaValue);
           expect(values).toHaveLength(index + 1);
         });
 
         it("can retrieve from NadaValues", () => {
           const record = values.to_record() as unknown as NadaValuesRecord;
-          const actual = record[test.name];
+          const actual = record[test.type];
           expect(actual).toBeDefined();
           expect(actual?.type).toEqual(test.type);
 

--- a/examples-nextjs/app/page.tsx
+++ b/examples-nextjs/app/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import {
-  NillionProvider,
   ClientBuilder,
+  NillionProvider,
   getKeplr,
 } from "@nillion/client-react-hooks";
 import type { VmClient } from "@nillion/client-vms";


### PR DESCRIPTION
This fixes the eddsa tests.

The main issue is that `NadaValue::create_eddsa_private_key()` works only with modular scalars, while `noble/ed25519.util.randomPrivateKey()` generates seed that can be greater than the curve order. For now, I have implemented a utility to calculate a valid scalar. 

Not sure if it would make sense, but if a user wanted to store this seed in the future we would have to revisit the nilvm implementation.